### PR TITLE
Updated Compatibility with WordPress v6.6.1 and PHP 8.2.0 & the plugi…

### DIFF
--- a/main.php
+++ b/main.php
@@ -4,7 +4,7 @@
  * Plugin Name: MemberPress Paystack
  * Plugin URI: https://wordpress.org/plugins/paystack-memberpress/
  * Description: Paystack integration for MemberPress.
- * Version: 1.3.4
+ * Version: 1.3.5
  * Author: Paystack
  * Author URI: https://paystack.com/
  * Developer: Wisdom Ebong

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: paystack, kaneahabagale
 Tags: paystack, billing, subscription, payment, memberpress,
 Requires at least: 5.1
-Tested up to: 6.6
+Tested up to: 6.6.1
 Requires PHP: 7.2 and higher
-Stable tag: 1.3.4
+Stable tag: 1.3.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -83,8 +83,8 @@ Here you can browse the source, look at open issues and keep track of developmen
  
 == Changelog ==
 
-= 1.3.4 - August 8, 2024 =
-*  Compatibility with WordPress 6.6 and PHP 8.2.0
+= 1.3.5 - August 8, 2024 =
+*  Compatibility with WordPress 6.6.1 and PHP 8.2.0
 
 = 1.3.3 =
 *  Fixed incorrect date set on expiredOn parameter 
@@ -97,8 +97,8 @@ Here you can browse the source, look at open issues and keep track of developmen
 
 == Upgrade Notice ==
 
-= 1.3.4 =
-*  Compatibility with WordPress 6.6 and PHP 8.2.0
+= 1.3.5 =
+*  Compatibility with WordPress 6.6.1 and PHP 8.2.0
 
 = 1.3.3 =
 *  Fixed incorrect date set on expiredOn parameter 


### PR DESCRIPTION
Updated Compatibility with WordPress v6.6.1 and PHP 8.2.0 & the plugin version number to 1.3.5